### PR TITLE
Update Dex to 2.35.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0]
+
+### Changed
+
+- Updated to [v2.35.3](https://github.com/dexidp/dex/releases/tag/v2.35.3)
+
 ## [1.2.0]
 
 ### Changed
@@ -24,7 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial release
 
-[unreleased]: https://github.com/karavel-io/platform-component-dex/compare/1.2.0...HEAD
+[unreleased]: https://github.com/karavel-io/platform-component-dex/compare/1.3.0...HEAD
+[1.3.0]: https://github.com/karavel-io/platform-component-dex/compare/1.1.0...1.3.0
 [1.2.0]: https://github.com/karavel-io/platform-component-dex/compare/1.1.0...1.2.0
 [1.1.0]: https://github.com/karavel-io/platform-component-dex/compare/1.0.0...1.1.0
 [1.0.0]: https://github.com/karavel-io/platform-component-dex/releases/tag/1.0.0

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,7 @@ This project follows the [SemVer 2.0] `MAJOR.MINOR.PATCH` format
 A minor release should introduce backward-compatible features and improvements. An end-user must be able to update from
 a minor release to the next (e.g. from `1.2.5` to `1.3.0`) without any manual intervention.
 
-To release a new minor version of this component, create a branch called `release/X.Y.0` (e.g. `release/1.3.0`) from `main`.
+To release a new minor version of this component, create a branch called `release/X.Y.0` (e.g. `release/1.4.0`) from `main`.
 This branch will host the last-minute changes and fixes in preparation for the actual release. Follow this release checklist:
 
 - [ ] Update the [CHANGELOG](CHANGELOG.md) by moving all `Unreleased` entries to a new section called `[X.Y.0] - YYYY-MM-DD`

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: dex
 description: Dex component for Karavel
 type: application
-version: 1.2.0-SNAPSHOT
-appVersion: 2.32.0
+version: 1.3.0-SNAPSHOT
+appVersion: 2.35.3
 maintainers:
   - name: MatteoJoliveau
     email: matteo.joliveau@mikamai.com

--- a/docs/1.3/configuration.md
+++ b/docs/1.3/configuration.md
@@ -1,0 +1,41 @@
+# Configuration
+
+```hcl
+component "dex" {
+  namespace = "dex" # optional
+
+  # Params default values
+
+  publicURL = "" # required, the full URL to reach the Dex instance, e.g. https://oauth.company.com
+
+  connectors = [
+    # Add your connectors here
+    # ...
+    # See https://dexidp.io/docs/connectors/ for available choices and their configuration schema
+
+    # Example entry
+    {
+      type = "github" # required, specify "github" for GitHub
+      id = "github"   # required, Connector ID
+      name = "GitHub" # required, Connector human readable name
+      config = {
+        # ... config fields as specified in https://dexidp.io/docs/connectors/github/
+      }
+  ]
+
+  secret = {
+    # override this section only if you are not using the default store from the external-secrets component
+    store = {
+      name = "default"
+      kind = "ClusterSecretStore"
+    }
+    key = "" # required, should be the store-specific key to the secret, e.g. the Vault or AWS Secrets Manager key
+  }
+}
+```
+
+## Secrets
+
+Secrets referenced by the configuration must be provisioned in the backend service of your choice before installing Dex.
+
+Unless you changed the configuration of the External Secret component or manually provisioned a custom `SecretStore` resource, you don't need to override the `store` section of each secret reference.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,3 +28,5 @@ nav:
     - 1.1/configuration.md
   - 1.2:
     - 1.2/configuration.md
+  - 1.3:
+    - 1.3/configuration.md


### PR DESCRIPTION
Just a quick update to Dex 2.35.x to fix a severe security issue, and make it possible to update ArgoCD to 2.4.13+